### PR TITLE
GEN-172

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,13 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-implicit-exception-spec-mismatch")
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
 # creative-engine path
-if ($ENV{CREATIVE_ENGINE_PATH})
-    set(CREATIVE_ENGINE_PATH, $ENV{CREATIVE_ENGINE_PATH})
+if (EXISTS $ENV{CREATIVE_ENGINE_PATH})
+    # set ENV variable in CLion project settings
+    set(CREATIVE_ENGINE_PATH $ENV{CREATIVE_ENGINE_PATH})
+    message(STATUS "Using user-defined creative-engine path: ${CREATIVE_ENGINE_PATH}")
 else()
     set(CREATIVE_ENGINE_PATH "${CMAKE_SOURCE_DIR}/../creative-engine")
+    message(STATUS "Falling back to default creative-engine path: ${CREATIVE_ENGINE_PATH}")
 endif()
 
 # resource compiler
@@ -18,16 +21,29 @@ set(RCOMP "${CREATIVE_ENGINE_PATH}/tools/rcomp")
 INCLUDE_DIRECTORIES(
     ${SDL2_INCLUDE_DIRS}
     ${SDL2IMAGE_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR} /usr/local/include
     ${CREATIVE_ENGINE_PATH}/src
     ${CREATIVE_ENGINE_PATH}/src/Widgets
-    ${CMAKE_BINARY_DIR} /usr/local/include
+    ${CREATIVE_ENGINE_PATH}/src/libxmp
+    ${CREATIVE_ENGINE_PATH}/src/libxmp/loaders
+    ${CREATIVE_ENGINE_PATH}/src/libxmp/loaders/prowizarde
 )
 
 # external libraries
 INCLUDE(FindPkgConfig)
 PKG_SEARCH_MODULE(SDL2 REQUIRED sdl2)
 PKG_SEARCH_MODULE(SDL2IMAGE REQUIRED SDL2_image>=2.0.0)
+
+# include creative-engine sources
+# when using out-of-tree source paths add_subdirectory's build_dir argument is required
+# use the project's current build directory
+
+# https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_BINARY_DIR.html
+# https://cmake.org/cmake/help/latest/command/add_subdirectory.html
+# https://stackoverflow.com/questions/35260552/how-do-i-explicitly-specify-an-out-of-tree-source-in-cmake
+add_subdirectory(${CREATIVE_ENGINE_PATH} ${CMAKE_CURRENT_BINARY_DIR}/creative-engine)
 
 # build rcomp
 add_custom_command(
@@ -50,20 +66,9 @@ add_custom_command(
 # gather creative-engine sources
 file(GLOB_RECURSE CREATIVE_ENGINE ${CREATIVE_ENGINE_PATH}/src/*.cpp)
 
-# gather game sources
-file(GLOB_RECURSE SRC RELATIVE ${CMAKE_SOURCE_DIR} "src/*.cpp")
-
-# LibXMP
+# gather LibXMP sources
 add_compile_definitions(LIBXMP_CORE_PLAYER=true)
 add_compile_definitions(LIBXMP_CORE_DISABLE_IT=true)
-
-include_directories(
-    ${CMAKE_SOURCE_DIR}/src
-    ${CREATIVE_ENGINE_PATH}/src/libxmp/loaders/prowizarde
-    ${CREATIVE_ENGINE_PATH}/src/libxmp/loaders
-    ${CREATIVE_ENGINE_PATH}/src/libxmp
-)
-
 file(
     GLOB LIBXMP_SRC
     ${CREATIVE_ENGINE_PATH}/src/libxmp/loaders/*.h
@@ -72,6 +77,7 @@ file(
     ${CREATIVE_ENGINE_PATH}/src/libxmp/*.c
 )
 
+# gather Genus sources
 file(GLOB_RECURSE GENUS_SRC RELATIVE ${CMAKE_SOURCE_DIR} "src/*.cpp")
 
 add_executable(


### PR DESCRIPTION
https://moduscreate.atlassian.net/browse/GEN-172

### Remove creative-engine symlink dependency from projects

User must set environment variables to `creative-engine` otherwise we fallback to `../creative-engine`
- ESP - set shell variable ie `export CREATIVE_ENGINE_PATH=~/engine`
- CLion - set variable in project settings

*Note:*
CLion does not parse the value of the ENV variables, the user must specify the absolute paths; for instance these would not work:
- $HOME/engine
- ~/engine

based on the above we are pulling in creative-engine as a project sub-directory (alongside the game dir)
We are making sure that the creative-engine build dir exists, otherwise we create it. This is required for pulling in creative-engine and build it.