### PR TITLE
GEN-359

### DIFF
--- a/src/GGame.cpp
+++ b/src/GGame.cpp
@@ -2,12 +2,17 @@
 
 static TUint32 start;
 
+#ifdef __XTENSA__
+static const TInt MAX_BRIGHTNESS = 0x1fff;
+static const TInt MIN_BRIGHTNESS = 0x50;
+#endif
+
 GGame::GGame() {
   // Load Game Options
   gOptions = new TOptions();
 
 #ifdef __XTENSA__
-  gDisplay.SetBrightness(0x1fff * gOptions->brightness);
+  gDisplay.SetBrightness(MAX(MIN_BRIGHTNESS, MAX_BRIGHTNESS * gOptions->brightness));
 #endif
 
   // TODO: Jay - this needs to be in BApplication constructor (I think)

--- a/src/MainOptionsState/GBrightnessWidget.cpp
+++ b/src/MainOptionsState/GBrightnessWidget.cpp
@@ -5,6 +5,11 @@ static const TRange brightness_options = {
   0, 8, 1
 };
 
+#ifdef __XTENSA__
+static const TInt MAX_BRIGHTNESS = 0x1fff;
+static const TInt MIN_BRIGHTNESS = 0x50;
+#endif
+
 GBrightnessWidget::GBrightnessWidget() : GSoundSliderWidget("SCREEN", &brightness_options, COLOR_TEXT, COLOR_TEXT_BG) {
   mHeight = 24;
 }
@@ -12,18 +17,17 @@ GBrightnessWidget::GBrightnessWidget() : GSoundSliderWidget("SCREEN", &brightnes
 GBrightnessWidget::~GBrightnessWidget() {}
 
 TInt GBrightnessWidget::Render(TInt aX, TInt aY) {
-  mSelectedValue = MAX(0, (gOptions->brightness / 0.125) - 2);
+  mSelectedValue = gOptions->brightness / 0.125;
   return GSoundSliderWidget::Render(aX, aY);
 }
 
 void GBrightnessWidget::Select(TInt aVal) {
-  aVal = MAX(1, aVal + 2);
   gOptions->brightness = aVal * 0.125f;
   gOptions->Save();
 
 #ifdef __XTENSA__
   // This widget shouldn't be added to non-xtensa devices
   // but let's be safe just in case
-  gDisplay.SetBrightness(0x1fff * gOptions->brightness);
+  gDisplay.SetBrightness(MAX(MIN_BRIGHTNESS, MAX_BRIGHTNESS * gOptions->brightness));
 #endif
 }


### PR DESCRIPTION
https://moduscreate.atlassian.net/browse/GEN-359

- Set brightness on boot
- Adjust read/write of brightness values

I would like to not have 2 places to change min/max brightness consts, I don't think we can extend the Display class as it's a global from the engine, I'd like to extract this to a better place.

```c++
#ifdef __XTENSA__
static const TInt MAX_BRIGHTNESS = 0x1fff;
static const TInt MIN_BRIGHTNESS = 0x50;
#endif

#ifdef __XTENSA__
  gDisplay.SetBrightness(MAX(MIN_BRIGHTNESS, MAX_BRIGHTNESS * gOptions->brightness));
#endif
```