### PR TITLE
Gen 394

### DIFF
--- a/src/GameState/GGameState.cpp
+++ b/src/GameState/GGameState.cpp
@@ -304,6 +304,7 @@ void GGameState::RenderNext() {
   BBitmap *bm = gDisplay.renderBitmap;
   bm->DrawStringShadow(ENull, "Next", mFont16, NEXT_X, NEXT_Y, COLOR_TEXT, COLOR_TEXT_SHADOW, -1, -6);
 
+  // On HARD difficulty draw a "?" over a filled block
   if (gOptions->difficulty == DIFFICULTY_HARD) {
     bm->DrawStringShadow(ENull, "?", mFont16, NEXT_BLOCK_X + 8, NEXT_BLOCK_Y + 8, COLOR_TEXT, COLOR_TEXT_SHADOW, -1);
   }

--- a/src/GameState/GPlayerSprite.cpp
+++ b/src/GameState/GPlayerSprite.cpp
@@ -90,6 +90,7 @@ TBool GPlayerSprite::Render(BViewPort *aVP) {
     if (mBlockSize == BLOCKSIZE_2x2) {
       TInt8 blocks[4];
 
+      // On HARD difficulty we show a filled NEXT block to the player
       if (gOptions->difficulty == DIFFICULTY_HARD && (flags & SFLAG_NEXT_BLOCK)) {
         memset(blocks, 0, sizeof(blocks));
       } else {


### PR DESCRIPTION
https://moduscreate.atlassian.net/browse/GEN-394

Hide `Next` block on HARD difficulty

- Fill the block with primary colors and draw a `?` on top of it if we're on HARD

Decided to go with a separate PR to be safe and be able to revert it case of fire.

![gen-394](https://user-images.githubusercontent.com/1321256/49857444-37d31880-fdfb-11e8-8d4a-bf6ccab92f22.gif)
