### PR TITLE
Gen 392

### DIFF
--- a/src/GSoundPlayer.cpp
+++ b/src/GSoundPlayer.cpp
@@ -40,6 +40,7 @@ void GSoundPlayer::Init(TUint8 aNumberFxChannels, TUint8 aNumberFxSlots) {
     slot->mRaw = gResourceManager.GetRaw(slot->mSlotNumber);
 
     mSongSlots[i] = *slot;
+    FreeMem(slot);
   }
 
 


### PR DESCRIPTION
https://moduscreate.atlassian.net/browse/GEN-392

:warning: Requires https://github.com/ModusCreateOrg/creative-engine/pull/133

- Free `slot` pointer as it is no longer needed, we are storing it's value in `mSongSlots` and releasing in `~BSoundPlayer`

Tested with Valgrind