### PR TITLE
Cmake fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,10 @@ PKG_SEARCH_MODULE(SDL2IMAGE REQUIRED SDL2_image>=2.0.0)
 # include creative-engine sources
 # when using out-of-tree source paths add_subdirectory's build_dir argument is required
 # use the project's current build directory
-# https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_BINARY_DIR.html
+# https://cmake.org/cmake/help/latest/variable/CMAKE_SOURCE_DIR.html
 # https://cmake.org/cmake/help/latest/command/add_subdirectory.html
 # https://stackoverflow.com/questions/35260552/how-do-i-explicitly-specify-an-out-of-tree-source-in-cmake
-add_subdirectory(${CREATIVE_ENGINE_PATH} ${CMAKE_CURRENT_BINARY_DIR}/creative-engine)
+add_subdirectory(${CREATIVE_ENGINE_PATH} ${CMAKE_SOURCE_DIR}/creative-engine)
 
 # build rcomp
 add_custom_command(


### PR DESCRIPTION
This allows for better navigation between symbols as it no longer links to the sources in the build dir.

:warning: Please test on Mac and other Linux distributions first please