### PR TITLE
Gen 395

### DIFF
--- a/src/GameState/Powerups/GColorSwapPowerup.cpp
+++ b/src/GameState/Powerups/GColorSwapPowerup.cpp
@@ -93,11 +93,7 @@ TBool GColorSwapPowerup::StateRemove() {
       if (mGameBoard->mBoard[p->mRow][p->mCol] == mSwapColor) {
         gSoundPlayer.SfxGoodDrop();
 
-        if (mSwapColor == IMG_TILE3 || mSwapColor == IMG_TILE4) {
-          mGameBoard->mBoard[p->mRow][p->mCol] = TUint8(mSwapColor == IMG_TILE3 ? IMG_TILE4 : IMG_TILE3);
-        } else {
-          mGameBoard->mBoard[p->mRow][p->mCol] = TUint8(mSwapColor == IMG_TILE1 ? IMG_TILE2 : IMG_TILE1);
-        }
+        mGameBoard->mBoard[p->mRow][p->mCol] = TUint8(mSwapColor == IMG_TILE1 ? IMG_TILE2 : IMG_TILE1);
 
         stack->Push(new Point(p->mRow - 1, p->mCol));
         stack->Push(new Point(p->mRow + 1, p->mCol));
@@ -115,8 +111,11 @@ TBool GColorSwapPowerup::StateRemove() {
 
 
 TBool GColorSwapPowerup::StateMove() {
+  TUint8 currentColor = mGameBoard->mBoard[mPlayerSprite->BoardRow()][mPlayerSprite->BoardCol()];
+
   if (gControls.WasPressed(BUTTONB)) {
-    if (mGameState->MainState() != STATE_REMOVE && mGameBoard->mBoard[mPlayerSprite->BoardRow()][mPlayerSprite->BoardCol()] != 255) {
+    // Placeable only on non-darkened blocks and during states other than removal of blocks
+    if (mGameState->MainState() != STATE_REMOVE && (currentColor == 0 || currentColor == 16)) {
       Drop();
       mState = STATE_REMOVE;
     }


### PR DESCRIPTION
https://moduscreate.atlassian.net/browse/GEN-395

Don't allow color-swap power-up to be placed on darkened blocks