### PR TITLE
Gen 396

### DIFF
--- a/src/GameState/Powerups/GColorSwapPowerup.cpp
+++ b/src/GameState/Powerups/GColorSwapPowerup.cpp
@@ -83,8 +83,6 @@ TBool GColorSwapPowerup::StateRemove() {
     return ETrue;
   }
 
-  mGameState->MainStateWait();
-
   mColorSwapTimer = 30 / 8;        // 1/8 second
 
   auto         *stack = (PointStack *) mPointStack;
@@ -119,6 +117,7 @@ TBool GColorSwapPowerup::StateMove() {
     if (mGameState->MainState() != STATE_REMOVE && mGameBoard->mBoard[mPlayerSprite->BoardRow()][mPlayerSprite->BoardCol()] != 255) {
       Drop();
       mState = STATE_REMOVE;
+      mGameState->MainStateWait();
     }
     else {
       // make bad drop sound

--- a/src/GameState/Powerups/GModusBombPowerup.cpp
+++ b/src/GameState/Powerups/GModusBombPowerup.cpp
@@ -50,6 +50,7 @@ TBool GModusBombPowerup::StateMove() {
     if (mGameState->MainState() != STATE_REMOVE) {
       Drop();
       mState = STATE_REMOVE;
+      mGameState->MainStateWait();
       mPlayerSprite->StartAnimation(BombDropAnimation);
     } else {
       gSoundPlayer.SfxBadDrop();
@@ -107,8 +108,6 @@ TBool GModusBombPowerup::StateRemove() {
   if (mBombTimer--) {
     return ETrue;
   }
-
-  mGameState->MainStateWait();
 
   mBombTimer = 30 / 4;        // 1/8 second
   TInt row = mBombRow,


### PR DESCRIPTION
https://moduscreate.atlassian.net/browse/GEN-396

Change the main game process to WAIT when we have confirmed a "good drop".
This fixes the bug of setting it to WAIT when timer was 0, when the game process ran *after* the bomb or color swap it never cleared the darkened-blocks as the bonus timer was -1.

Tested this and other edge cases by doing programmatically placing powerups when timer was 0 or -1 (separate tests) all have resulted in bad drops and no unexpected behaviour.

```c++
  if (mGameState->mBonusTimer <= 0 || gControls.WasPressed(BUTTONB)) {
    // Good drop logic
  }
```