### PR TITLE
Gen 397

### DIFF
--- a/src/GSoundPlayer.cpp
+++ b/src/GSoundPlayer.cpp
@@ -54,7 +54,11 @@ void GSoundPlayer::Init(TUint8 aNumberFxChannels, TUint8 aNumberFxSlots) {
 
 TBool GSoundPlayer::PlayMusic(TInt16 aResourceId) {
   TBool music = BSoundPlayer::PlayMusic(aResourceId);
-//  MuteMusic(gOptions->muted);
+
+  // BSoundPlayer::PlayMusic un-mutes the music
+  // We have to re-mute it in case of mute == true
+  MuteMusic(gOptions->muted);
+
   return music;
 }
 


### PR DESCRIPTION
https://moduscreate.atlassian.net/browse/GEN-397

We need to call Mute after `BSoundPlaye::PlayMusic` as it calls `Mute(false)` at the very end, the result is that it unmutes itself when new songs are played (including power-cycling the device or resetting the game)