### PR TITLE
210

### DIFF
--- a/src/GameState/GGameBoard.cpp
+++ b/src/GameState/GGameBoard.cpp
@@ -156,17 +156,15 @@ void GGameBoard::Dump() {
   }
 }
 
-TInt GGameBoard::CountColorSwappableBlocks() {
-  TInt swappableBlocks = 0;
-
+TBool GGameBoard::HasColorSwappableBlocks() {
   for (TInt row = 0; row < BOARD_ROWS; row++) {
     for (TInt col = 0; col < BOARD_COLS; col++) {
       TUint8 v = mBoard[row][col];
       if (v == IMG_TILE1 || v == IMG_TILE2) {
-        swappableBlocks++;
+        return ETrue;
       }
     }
   }
 
-  return swappableBlocks;
+  return EFalse;
 }

--- a/src/GameState/GGameBoard.h
+++ b/src/GameState/GGameBoard.h
@@ -65,7 +65,7 @@ public:
   /**
    * Return how many color-swappable blocks are there on the playefield
    */
-  TInt CountColorSwappableBlocks();
+  TBool HasColorSwappableBlocks();
 
 public:
 

--- a/src/GameState/GGameState.cpp
+++ b/src/GameState/GGameState.cpp
@@ -128,7 +128,7 @@ void GGameState::Next(TBool aCanPowerup) {
       if (Random() & 1) {
         AddProcess(new GModusBombPowerup(mSprite, this));
         return;
-      } else if (mGameBoard.CountColorSwappableBlocks() > 0) {
+      } else if (mGameBoard.HasColorSwappableBlocks()) {
         AddProcess(new GColorSwapPowerup(mSprite, this));
         return;
       }


### PR DESCRIPTION
Fixes #210 

Before spawning the color-swap powerup, check if the playfield contains any color-swappable blocks