### PR TITLE
Fix issue with cwd in cmake build

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -61,6 +61,7 @@ function ensure_cmake {
         make
         $SUDO make install
     fi
+    cd - || exit 1
     rm -rf "$tmpdir"
 }
 


### PR DESCRIPTION
Change directory to previous before removing tmpdir after building `cmake` from source, avoiding
a problem where script bombs when it can't determine the current directory.

Tested on an ARM 64 bit build, but could really happen anywhere:

```
admin@ip-10-0-0-80:~/genus$ arch
aarch64
admin@ip-10-0-0-80:~/genus$ uname -a
Linux ip-10-0-0-80 4.9.0-8-arm64 #1 SMP Debian 4.9.144-3 (2019-02-02) aarch64 GNU/Linux
admin@ip-10-0-0-80:~/genus$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 9.8 (stretch)
Release:	9.8
Codename:	stretch
admin@ip-10-0-0-80:~/genus$
```

Without this fix, you might need to run `./scripts/build.sh` twice on some platforms to get this to build.