### PR TITLE
Cleanup gitignore entries not related to a C++ project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,15 +6,6 @@
 !.travis.yml
 !.ci
 
-# ignore node/grunt dependency directories
-node_modules/
-
-# ignore composer vendor directory
-/vendor
-
-# ignore components loaded via Bower
-/bower_components
-
 # ignore OS generated files
 ehthumbs.db
 Thumbs.db
@@ -35,43 +26,10 @@ Thumbs.db
 *.log
 
 # ignore packaged files
-*.7z
 *.dmg
 *.gz
-*.iso
-*.jar
-*.rar
 *.tar
 *.zip
-
-# ignore common folders (uncomment to enable)
-# build/
-# public/
-# screenshots/
-# coverage/
-# reports/
-# *cache/
-
-# wordpress
-wp-config.php
-wp-content/advanced-cache.php
-wp-content/backup-db/
-wp-content/backups/
-wp-content/blogs.dir/
-wp-content/cache/
-wp-content/upgrade/
-wp-content/uploads/
-wp-content/mu-plugins/
-wp-content/wp-cache-config.php
-wp-content/plugins/hello.php
-
-# common web
-/.htaccess
-/sitemap.xml
-/sitemap.xml.gz
-
-# doxygen
-/docs
 
 # -------------------------
 # BEGIN Whitelisted Files


### PR DESCRIPTION
I left some more common types of package files -- if a packaged build is designed.

References https://github.com/ModusCreateOrg/genus/issues/232